### PR TITLE
Wrong module declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module caption_json_formatter
+module github.com/nolleh/caption_json_formatter
 
 
 go 1.12


### PR DESCRIPTION
I have problems using your package. I can't import it properly.

Problem:
```
go: finding module for package github.com/nolleh/caption_json_formatter
go: found github.com/nolleh/caption_json_formatter in github.com/nolleh/caption_json_formatter v0.0.0-20200123044416-f86ae6853e09
go: github.com/lanvard/foundation/test/log tested by
	github.com/lanvard/foundation/test/log.test imports
	github.com/nolleh/caption_json_formatter: github.com/nolleh/caption_json_formatter@v0.0.0-20200123044416-f86ae6853e09: parsing go.mod:
	module declares its path as: caption_json_formatter
	        but was required as: github.com/nolleh/caption_json_formatter
```